### PR TITLE
Remove setuptools dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 5.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Remove setuptools dependency
 
 
 5.0 (2022-09-08)

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ setup(name="zope.dottedname",
       packages=find_packages('src'),
       package_dir={'': 'src'},
       namespace_packages=['zope'],
-      install_requires=['setuptools'],
       extras_require={
           'testing': [],
           'docs': [


### PR DESCRIPTION
Looks like this is not needed for a lib runtime, only for the installation.

This will allow to workaround some problems with other build tools like this one https://github.com/python-poetry/poetry/issues/4242